### PR TITLE
[Backend] Protect image upload endpoints with JwtAuthGuard

### DIFF
--- a/backend/src/uploads/uploads.controller.ts
+++ b/backend/src/uploads/uploads.controller.ts
@@ -1,8 +1,10 @@
-import { Controller, Post, UseInterceptors, UploadedFile, UploadedFiles, BadRequestException } from '@nestjs/common';
+import { Controller, Post, UseInterceptors, UseGuards, UploadedFile, UploadedFiles, BadRequestException } from '@nestjs/common';
 import { FileInterceptor, FilesInterceptor } from '@nestjs/platform-express';
 import { UploadsService } from './uploads.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 
 @Controller('uploads')
+@UseGuards(JwtAuthGuard)
 export class UploadsController {
   constructor(private readonly uploadsService: UploadsService) {}
 


### PR DESCRIPTION
## Summary

Adds JWT authentication to image upload endpoints to prevent unauthorized uploads.

## Changes
- Added `@UseGuards(JwtAuthGuard)` to `UploadsController`
- Both `POST /api/uploads/image` and `POST /api/uploads/images` now require valid JWT token
- Unauthorized requests return 401 with appropriate error message
- Existing validation for image MIME type and file size remains intact

## Acceptance Criteria (from #12, #22)
- [x] POST /api/uploads/image requires valid JWT
- [x] POST /api/uploads/images requires valid JWT  
- [x] Unauthorized requests receive 401 error
- [x] Existing image type/size validation still works

## Testing
```bash
# Without token - should fail with 401
curl -X POST http://localhost:3001/api/uploads/image -F "file=@test.jpg"

# With valid token - should succeed
curl -X POST http://localhost:3001/api/uploads/image -H "Authorization: Bearer <token>" -F "file=@test.jpg"
```

## Related Issues
- Closes #12
- Closes #22
- Unblocks #14 (image upload end-to-end wiring)

## Next Steps
- Update CreatePropertyDto/UpdatePropertyDto with images field (#14)
- Frontend image upload UI (#14)